### PR TITLE
Fix trailing newline in AK/SK credentials due to missing echo -n

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -597,8 +597,8 @@ Please visit the [Hivelocity project][Hivelocity provider].
 
 ```bash
 # Please ensure that the values for `CLOUD_SDK_AK` and `CLOUD_SDK_SK` are base64 encoded.
-export CLOUD_SDK_AK=$( echo $AccessKey | base64 | tr -d '\n' )
-export CLOUD_SDK_SK=$( echo $SecretKey | base64 | tr -d '\n' )
+export CLOUD_SDK_AK=$( echo -n "$AccessKey" | base64 | tr -d '\n' )
+export CLOUD_SDK_SK=$( echo -n "$SecretKey" | base64 | tr -d '\n' )
 
 # Finally, initialize the management cluster
 clusterctl init --infrastructure huawei
@@ -1141,7 +1141,7 @@ See the [Harvester provider] for more information.
 
 ```bash
 # huawei cloud region
-export HC_REGION="cn-east-1"
+export HC_REGION="ap-southeast-1"
 # ECS SSH key name
 export HC_SSH_KEY_NAME="default"
 # kubernetes version
@@ -1151,11 +1151,11 @@ export CONTROL_PLANE_MACHINE_COUNT="1"
 # number of worker machines
 export WORKER_MACHINE_COUNT="1"
 # control plane machine type
-export HC_CONTROL_PLANE_MACHINE_TYPE="x1e.2u.4g"
+export HC_CONTROL_PLANE_MACHINE_TYPE="x1.2u.4g"
 # worker node machine type
-export HC_NODE_MACHINE_TYPE="x1e.2u.4g"
+export HC_NODE_MACHINE_TYPE="x1.2u.4g"
 # ECS image ID
-export ECS_IMAGE_ID="218ca5t7-bxf3-5dg0-852p-y703c9fe1a52"
+export ECS_IMAGE_ID="4e98ff86-1c31-4ede-997c-44c39e618fd3"
 ```
 
 See the [Huawei Cloud provider] for more information.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR resolves an issue where Base64-encoded credentials (AK/SK) unintentionally contained trailing newline characters (\n), causing downstream systems to read invalid credentials.

The original command echo $AccessKey | base64 added an implicit newline to the input string (default echo behavior), which was then encoded into the Base64 output. While tr -d '\n' removed line breaks from the Base64 output, it did not address the newline already embedded in the input data.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->